### PR TITLE
Use openai api key from APIKeys

### DIFF
--- a/prediction_prophet/autonolas/research.py
+++ b/prediction_prophet/autonolas/research.py
@@ -35,6 +35,7 @@ from prediction_market_agent_tooling.gtypes import Probability
 from prediction_market_agent_tooling.tools.utils import secret_str_from_env
 from prediction_prophet.functions.cache import persistent_inmemory_cache
 from prediction_prophet.functions.parallelism import par_map
+from prediction_market_agent_tooling.config import APIKeys
 from pydantic.types import SecretStr
 from prediction_market_agent_tooling.gtypes import secretstr_to_v1_secretstr
 from langfuse.decorators import langfuse_context
@@ -1220,7 +1221,7 @@ def make_prediction(
     api_key: SecretStr | None = None,
 ) -> Prediction:
     if api_key == None:
-        api_key = secret_str_from_env("OPENAI_API_KEY")
+        api_key = APIKeys().openai_api_key
     
     current_time_utc = datetime.now(timezone.utc)
     formatted_time_utc = current_time_utc.strftime("%Y-%m-%dT%H:%M:%S.%f")[:-6] + "Z"

--- a/prediction_prophet/functions/create_embeddings_from_results.py
+++ b/prediction_prophet/functions/create_embeddings_from_results.py
@@ -13,13 +13,13 @@ from langchain.vectorstores.chroma import Chroma
 from prediction_prophet.models.WebScrapeResult import WebScrapeResult
 from langchain.text_splitter import RecursiveCharacterTextSplitter
 from pydantic.types import SecretStr
-from prediction_market_agent_tooling.tools.utils import secret_str_from_env
+from prediction_market_agent_tooling.config import APIKeys
 from prediction_market_agent_tooling.gtypes import secretstr_to_v1_secretstr
 
 
 def create_embeddings_from_results(results: list[WebScrapeResult], text_splitter: RecursiveCharacterTextSplitter, api_key: SecretStr | None = None) -> Chroma:
     if api_key == None:
-        api_key = secret_str_from_env("OPENAI_API_KEY")
+        api_key = APIKeys().openai_api_key
     
     collection = Chroma(embedding_function=OpenAIEmbeddings(api_key=secretstr_to_v1_secretstr(api_key)))
     texts = []

--- a/prediction_prophet/functions/debate_prediction.py
+++ b/prediction_prophet/functions/debate_prediction.py
@@ -9,7 +9,7 @@ from pydantic import SecretStr
 from langchain.schema.output_parser import StrOutputParser
 from langchain_openai import ChatOpenAI
 from langchain.prompts import ChatPromptTemplate
-from prediction_market_agent_tooling.tools.utils import secret_str_from_env
+from prediction_market_agent_tooling.config import APIKeys
 from prediction_market_agent_tooling.gtypes import secretstr_to_v1_secretstr
 
 
@@ -85,7 +85,7 @@ give you convincing arguments. Nonetheless, be strong in your position and argum
     
 def make_debated_prediction(prompt: str, additional_information: str, api_key: SecretStr | None = None) -> Prediction:
     if api_key == None:
-        api_key = secret_str_from_env("OPENAI_API_KEY")
+        api_key = APIKeys().openai_api_key
         
     formatted_time_utc = datetime.datetime.now(datetime.timezone.utc).isoformat(timespec='seconds') + "Z"
     

--- a/prediction_prophet/functions/generate_subqueries.py
+++ b/prediction_prophet/functions/generate_subqueries.py
@@ -3,7 +3,7 @@ from langchain_openai import ChatOpenAI
 from langchain.output_parsers import CommaSeparatedListOutputParser
 from langchain.prompts import ChatPromptTemplate
 from pydantic.types import SecretStr
-from prediction_market_agent_tooling.tools.utils import secret_str_from_env
+from prediction_market_agent_tooling.config import APIKeys
 from prediction_market_agent_tooling.gtypes import secretstr_to_v1_secretstr
 from prediction_market_agent_tooling.tools.langfuse_ import get_langfuse_langchain_config, observe
 
@@ -22,7 +22,7 @@ def generate_subqueries(query: str, limit: int, model: str, temperature: float, 
         return [query]
 
     if api_key == None:
-        api_key = secret_str_from_env("OPENAI_API_KEY")
+        api_key = APIKeys().openai_api_key
             
     subquery_generation_prompt = ChatPromptTemplate.from_template(template=subquery_generation_template)
 

--- a/prediction_prophet/functions/prepare_report.py
+++ b/prediction_prophet/functions/prepare_report.py
@@ -6,7 +6,7 @@ from langchain.prompts import ChatPromptTemplate
 from langchain.schema.output_parser import StrOutputParser
 from prediction_prophet.functions.cache import persistent_inmemory_cache
 from prediction_prophet.functions.utils import trim_to_n_tokens
-from prediction_market_agent_tooling.tools.utils import secret_str_from_env
+from prediction_market_agent_tooling.config import APIKeys
 from pydantic.types import SecretStr
 from prediction_market_agent_tooling.gtypes import secretstr_to_v1_secretstr
 from prediction_market_agent_tooling.tools.langfuse_ import get_langfuse_langchain_config, observe
@@ -15,7 +15,7 @@ from prediction_market_agent_tooling.tools.langfuse_ import get_langfuse_langcha
 @observe()
 def prepare_summary(goal: str, content: str, model: str, api_key: SecretStr | None = None, trim_content_to_tokens: t.Optional[int] = None) -> str:
     if api_key == None:
-        api_key = secret_str_from_env("OPENAI_API_KEY")
+        api_key = APIKeys().openai_api_key
     
     prompt_template = """Write comprehensive summary of the following web content, that provides relevant information to answer the question: '{goal}'.
 But cut the fluff and keep it up to the point.
@@ -45,7 +45,7 @@ Content:
 @observe()
 def prepare_report(goal: str, scraped: list[str], model: str, temperature: float, api_key: SecretStr | None = None) -> str:
     if api_key == None:
-        api_key = secret_str_from_env("OPENAI_API_KEY")
+        api_key = APIKeys().openai_api_key
         
     evaluation_prompt_template = """
     You are a professional researcher. Your goal is to provide a relevant information report

--- a/prediction_prophet/functions/rerank_subqueries.py
+++ b/prediction_prophet/functions/rerank_subqueries.py
@@ -3,7 +3,7 @@ from langchain_openai import ChatOpenAI
 from langchain.prompts import ChatPromptTemplate
 from langchain.schema.output_parser import StrOutputParser
 from pydantic.types import SecretStr
-from prediction_market_agent_tooling.tools.utils import secret_str_from_env
+from prediction_market_agent_tooling.config import APIKeys
 from prediction_market_agent_tooling.gtypes import secretstr_to_v1_secretstr
 from prediction_market_agent_tooling.tools.langfuse_ import get_langfuse_langchain_config, observe
 
@@ -20,7 +20,7 @@ Queries: {queries}
 @observe()
 def rerank_subqueries(queries: list[str], goal: str, model: str, temperature: float, api_key: SecretStr | None = None) -> list[str]:
     if api_key == None:
-        api_key = secret_str_from_env("OPENAI_API_KEY")
+        api_key = APIKeys().openai_api_key
             
     rerank_results_prompt = ChatPromptTemplate.from_template(template=rerank_queries_template)
 


### PR DESCRIPTION
Previously, as APIKeys weren't used, the agent running locally would error out if the API key was specified only in .env file (which we suggest to do).