### PR TITLE
Add Trustabl Agent Scanner to CI

### DIFF
--- a/.github/workflows/trustabl.yml
+++ b/.github/workflows/trustabl.yml
@@ -1,0 +1,17 @@
+name: Trustabl
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+permissions:
+  contents: read
+  security-events: write
+  pull-requests: write
+
+jobs:
+  scan:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: trustabl/trustabl-action@v0


### PR DESCRIPTION
We came across your repo and we like how you're building an AI that can make predictions based on web research, which seems very useful for understanding current events and trends. We scanned the repo, and noticed agent runtime reliability findings that might be worth reviewing.

1. [LOW] AutoGen project ships no agent-guidance doc (AGENTS.md/CLAUDE.md)
   File: AGENTS.md
   What it means: The project uses AutoGen in code but ships no agent-guidance doc (AGENTS.md/CLAUDE.md), which can make understanding and debugging agent behavior more difficult.

2. [LOW] Pydantic AI project ships no agent-guidance doc (AGENTS.md/CLAUDE.md)
   File: AGENTS.md
   What it means: The project uses Pydantic AI in code but ships no agent-guidance doc (AGENTS.md/CLAUDE.md), which can make understanding and debugging agent behavior more difficult.

3. [LOW] Pydantic AI agent has no structured output validation
   File: prediction_prophet/app.py
   What it means: This agent does not constrain its output to a validated type: output_type is absent (defaulting to free-form str) or set explicitly to str, which can lead to unexpected behavior and make it harder to integrate the agent with other systems.

Recommendations are based on our understanding of agent runtime reliability, some findings may be intentional. Please let us know if this was intentional or if our findings are helpful so we can improve the accuracy of the scanner.

Best,
Trustabl.ai
Open-source AI agent reliability scanner (runs locally, GitHub Action)